### PR TITLE
Add InfraScan audit workflow to GitHub Actions

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,34 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/scan \
+            soldevelo/infrascan:latest \
+            --scanner comprehensive \
+            --format html \
+            --out /scan/infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
## Description
This PR introduces an automated infrastructure security audit by integrating InfraScan into our GitHub Actions pipeline. 

## Key Changes
* **New Workflow Added:** Created `.github/workflows/infrascan.yml` to automatically trigger on `push` and `pull_request` events.
* **Comprehensive Scanning:** Configured a job to run the `soldevelo/infrascan:latest` Docker image using the `--scanner comprehensive` flag.
* **Automated Reporting:** The scan outputs an HTML report, which is then automatically uploaded as a GitHub Actions artifact (`infrascan-report`). 
* **Artifact Retention:** The report is configured to be retained for 14 days and will be uploaded even if the scan step fails (`if: always()`), ensuring we always have access to the audit logs.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update